### PR TITLE
GH-53 City and Provider are transparently set

### DIFF
--- a/app/controllers/admin/beneficiaries_controller.rb
+++ b/app/controllers/admin/beneficiaries_controller.rb
@@ -21,7 +21,8 @@ module Admin
     def create
       resource = resource_class.new(resource_params)
       if current_user.provider?
-        resource.provider_id = current_user.provider.id
+        resource.provider = current_user.provider
+        resource.city = current_user.provider.city
         resource.is_active = false
       end
       authorize_resource(resource)

--- a/app/views/admin/beneficiaries/_form.html.erb
+++ b/app/views/admin/beneficiaries/_form.html.erb
@@ -52,13 +52,37 @@ end
     <% end %>
     <% next if !current_user.shop? && !current_user.administrator? && !current_user.provider? %>
     <% if current_user.provider? %>
-      <% next if [:provider, :is_active].include?(attribute.attribute) %>
-      <% if attribute.attribute == :max_shop_count && page.resource.persisted? %>
-        <div class="field-unit__label">
-          <%= f.label attribute.attribute %>
+      <% next if [:is_active].include?(attribute.attribute) %>
+      <% if attribute.attribute == :provider %>
+        <div class="field-unit field-unit--<%= attribute.html_class %>">
+          <div class="field-unit__label">
+            <%= f.label attribute.attribute %>
+          </div>
+          <div class="field-unit__field">
+            <%= current_user.provider.name %>
+          </div>
         </div>
-        <div class="field-unit__field">
-          <%= render locals: { field: attribute }, partial: "/fields/#{attribute.class.to_s.demodulize.underscore}/show" %>
+        <% next %>
+      <% end %>
+      <% if attribute.attribute == :city %>
+        <div class="field-unit field-unit--<%= attribute.html_class %>">
+          <div class="field-unit__label">
+            <%= f.label attribute.attribute %>
+          </div>
+          <div class="field-unit__field">
+            <%= current_user.provider.city.name %>
+          </div>
+        </div>
+        <% next %>
+      <% end %>
+      <% if attribute.attribute == :max_shop_count && page.resource.persisted? %>
+        <div class="field-unit field-unit--<%= attribute.html_class %>">
+          <div class="field-unit__label">
+            <%= f.label attribute.attribute %>
+          </div>
+          <div class="field-unit__field">
+            <%= render locals: { field: attribute }, partial: "/fields/#{attribute.class.to_s.demodulize.underscore}/show" %>
+          </div>
         </div>
         <% next %>
       <% end %>


### PR DESCRIPTION
- Sets city_id when creating the record and avoid the related input to 
be shown in the form.
- Refactors the attributes so that they're correctly wrapped within a 
div container.
- Shows the provider name as a label within the form.